### PR TITLE
fix: wrong id on DankPomodoro

### DIFF
--- a/DankPomodoroTimer/DankPomodoroSettings.qml
+++ b/DankPomodoroTimer/DankPomodoroSettings.qml
@@ -7,7 +7,7 @@ import qs.Modules.Plugins
 
 PluginSettings {
     id: root
-    pluginId: "pomodoroTimer"
+    pluginId: "dankPomodoroTimer"
 
     StyledText {
         width: parent.width

--- a/DankPomodoroTimer/plugin.json
+++ b/DankPomodoroTimer/plugin.json
@@ -2,7 +2,7 @@
     "id": "dankPomodoroTimer",
     "name": "Dank Pomodoro Timer",
     "description": "Productivity timer with 25-minute work sessions and breaks",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "author": "Avenge Media",
     "icon": "timer",
     "firstParty": true,


### PR DESCRIPTION
The issue was in DankPomodoroTimer/DankPomodoroSettings.qml:10 where the pluginId was set to "pomodoroTimer" instead of "dankPomodoroTimer" to match the plugin ID in plugin.json.

This mismatch caused:

- System settings (like enabled) to be saved under dankPomodoroTimer
- User settings (like autoStartBreaks, autoStartPomodoros) to be saved under pomodoroTimer

This fix will break existing settings, users will have to consolidade their pomodoroTimer under the correct dankPomodoroTimer section of plugin_settings.