### PR TITLE
(fix) DankPomodoroWidget.qml: Theme.success -> Theme.info

### DIFF
--- a/DankPomodoroTimer/DankPomodoroWidget.qml
+++ b/DankPomodoroTimer/DankPomodoroWidget.qml
@@ -266,7 +266,7 @@ PluginComponent {
         if (globalTimerState.value === "work")
             return Theme.primary
         if (globalTimerState.value === "shortBreak")
-            return Theme.success
+            return Theme.info
         return Theme.warning
     }
 


### PR DESCRIPTION
Change `Theme.success` to `Theme.info` for the accent color used in the short break of the Pomodoro Timer, because `Theme.success` is not an attribute in users' custom themes. 


<img width="392" height="604" alt="image" src="https://github.com/user-attachments/assets/531ccc29-af38-4af8-90bf-cc010c80d82e" />

<img width="385" height="603" alt="image" src="https://github.com/user-attachments/assets/94ed285c-9007-4a7c-94a5-69e99c794565" />
