### PR TITLE
Add DankCleaner plugin

### DIFF
--- a/DankCleaner/CleanerService.qml
+++ b/DankCleaner/CleanerService.qml
@@ -1,0 +1,466 @@
+pragma Singleton
+
+import QtQuick
+import Quickshell
+import Quickshell.Io
+
+Singleton {
+    id: root
+
+    property bool cleanupCache: true
+    property bool cleanupTrash: true
+    property bool cleanupBrowserCache: true
+    property bool cleanupTmp: false
+    property int tmpAgeDays: 3
+    property int largeFileThresholdMb: 100
+    property string largeFilePaths: "~/Downloads\n~/Videos\n~/Documents"
+    property string excludePatterns: ""
+    property string diskAnalyzerPaths: "~/Downloads\n~/Documents\n~/Videos\n~/Pictures"
+
+    property bool running: false
+    property string statusText: "Idle"
+    property real totalCleanupBytes: 0
+    property string totalCleanupLabel: "0 B reclaimable"
+    property string totalCleanupShort: "0B"
+
+    property real cacheBytes: 0
+    property real trashBytes: 0
+    property real browserCacheBytes: 0
+    property real tmpBytes: 0
+
+    property var largeFiles: []
+    property real lastCleanupBytes: 0
+    property string lastCleanupLabel: "0 B"
+
+    property var diskTopDirs: []
+    property var diskCategoryBuckets: []
+    property real diskTotalBytes: 0
+    property bool refreshPending: false
+
+    readonly property string homeDir: Quickshell.env("HOME") || ""
+
+    Component {
+        id: cmdRunner
+        Process {
+            id: cmdProc
+            property string shellCmd: ""
+            property var onFinished: null
+            command: ["bash", "-lc", shellCmd]
+            stdout: StdioCollector {
+                onStreamFinished: {
+                    if (cmdProc.onFinished) cmdProc.onFinished(text);
+                }
+            }
+            stderr: StdioCollector {}
+            onExited: {
+                cmdProc.destroy();
+            }
+        }
+    }
+
+    function run(shellCmd, cb) {
+        var p = cmdRunner.createObject(root, { shellCmd: shellCmd, onFinished: cb });
+        p.running = true;
+    }
+
+    function shellQuote(input) {
+        return "'" + String(input).replace(/'/g, "'\"'\"'") + "'";
+    }
+
+    function formatBytes(bytes) {
+        var v = Number(bytes) || 0;
+        if (v <= 0) return "0 B";
+        var units = ["B", "KB", "MB", "GB", "TB"];
+        var u = 0;
+        while (v >= 1024 && u < units.length - 1) {
+            v /= 1024;
+            u++;
+        }
+        var precision = v >= 10 || u === 0 ? 0 : 1;
+        return v.toFixed(precision) + " " + units[u];
+    }
+
+    function formatShort(bytes) {
+        var text = formatBytes(bytes);
+        return text.replace(" ", "");
+    }
+
+    function parseNumber(text) {
+        var n = parseInt(String(text).trim(), 10);
+        return isNaN(n) ? 0 : n;
+    }
+
+    function expandTilde(pathValue) {
+        if (!pathValue) return "";
+        var p = String(pathValue).trim();
+        if (p.indexOf("~/") === 0) return root.homeDir + p.substring(1);
+        if (p === "~") return root.homeDir;
+        return p;
+    }
+
+    function safeHomePath(pathValue) {
+        var p = expandTilde(pathValue);
+        return p.length > 1 && p.indexOf(root.homeDir + "/") === 0;
+    }
+
+    function normalizeSearchPaths() {
+        return normalizePaths(root.largeFilePaths, [root.homeDir + "/Downloads", root.homeDir + "/Videos", root.homeDir + "/Documents"]);
+    }
+
+    function normalizePaths(rawValue, fallbackPaths) {
+        var raw = String(rawValue || "").split(/\n|,/);
+        var out = [];
+        for (var i = 0; i < raw.length; i++) {
+            var item = expandTilde(raw[i]);
+            if (!item || !safeHomePath(item)) continue;
+            if (out.indexOf(item) === -1) out.push(item);
+        }
+        if (out.length === 0) out = fallbackPaths;
+        return out;
+    }
+
+    function patternToRegex(pattern) {
+        var s = String(pattern).trim();
+        if (!s) return null;
+        var escaped = s.replace(/[.+^${}()|[\]\\]/g, "\\$&");
+        escaped = escaped.replace(/\*/g, ".*").replace(/\?/g, ".");
+        try {
+            return new RegExp("^" + escaped + "$");
+        } catch (err) {
+            return null;
+        }
+    }
+
+    function parseExclusionRegexes() {
+        var rows = String(root.excludePatterns || "").split(/\n|,/);
+        var rules = [];
+        for (var i = 0; i < rows.length; i++) {
+            var row = rows[i].trim();
+            if (!row) continue;
+            var full = row.indexOf("~/") === 0 || row === "~" ? expandTilde(row) : row;
+            var rx = patternToRegex(full);
+            if (rx) rules.push(rx);
+        }
+        return rules;
+    }
+
+    function isExcluded(pathValue, regexes) {
+        for (var i = 0; i < regexes.length; i++) {
+            if (regexes[i].test(pathValue)) return true;
+        }
+        return false;
+    }
+
+    function refreshAll() {
+        if (running) {
+            refreshPending = true;
+            return;
+        }
+        running = true;
+        statusText = "Scanning cleanup categories";
+        estimateCleanup(function() {
+            statusText = "Scanning large files";
+            scanLargeFiles(function() {
+                statusText = "Analyzing disk usage";
+                scanDiskUsage(function() {
+                    running = false;
+                    statusText = "Ready";
+                    if (refreshPending) {
+                        refreshPending = false;
+                        Qt.callLater(refreshAll);
+                    }
+                });
+            });
+        });
+    }
+
+    function updateTotals() {
+        totalCleanupBytes = (cleanupCache ? cacheBytes : 0)
+            + (cleanupTrash ? trashBytes : 0)
+            + (cleanupBrowserCache ? browserCacheBytes : 0)
+            + (cleanupTmp ? tmpBytes : 0);
+        totalCleanupLabel = formatBytes(totalCleanupBytes) + " reclaimable";
+        totalCleanupShort = formatShort(totalCleanupBytes);
+    }
+
+    function estimateCleanup(done) {
+        var steps = [];
+
+        steps.push(function(next) {
+            if (!cleanupCache) {
+                cacheBytes = 0;
+                next();
+                return;
+            }
+            run("du -sb \"$HOME/.cache\" 2>/dev/null | awk '{print $1}'", function(out) {
+                cacheBytes = parseNumber(out);
+                next();
+            });
+        });
+
+        steps.push(function(next) {
+            if (!cleanupTrash) {
+                trashBytes = 0;
+                next();
+                return;
+            }
+            var cmd = "du -sb \"$HOME/.local/share/Trash/files\" \"$HOME/.local/share/Trash/info\" 2>/dev/null | awk '{sum+=$1} END{print sum+0}'";
+            run(cmd, function(out) {
+                trashBytes = parseNumber(out);
+                next();
+            });
+        });
+
+        steps.push(function(next) {
+            if (!cleanupBrowserCache) {
+                browserCacheBytes = 0;
+                next();
+                return;
+            }
+            var cmd = "du -sb \"$HOME/.cache/mozilla\" \"$HOME/.cache/google-chrome\" \"$HOME/.cache/chromium\" 2>/dev/null | awk '{sum+=$1} END{print sum+0}'";
+            run(cmd, function(out) {
+                browserCacheBytes = parseNumber(out);
+                next();
+            });
+        });
+
+        steps.push(function(next) {
+            if (!cleanupTmp) {
+                tmpBytes = 0;
+                next();
+                return;
+            }
+            var age = Math.max(1, parseInt(tmpAgeDays) || 3);
+            var cmd = "find /tmp -maxdepth 1 -user \"$USER\" -mtime +" + age + " -print0 2>/dev/null | du --files0-from=- -cb 2>/dev/null | tail -n 1 | awk '{print $1+0}'";
+            run(cmd, function(out) {
+                tmpBytes = parseNumber(out);
+                next();
+            });
+        });
+
+        runSequence(steps, function() {
+            updateTotals();
+            if (done) done();
+        });
+    }
+
+    function runSequence(steps, onDone) {
+        var i = 0;
+        function next() {
+            if (i >= steps.length) {
+                if (onDone) onDone();
+                return;
+            }
+            var step = steps[i++];
+            step(next);
+        }
+        next();
+    }
+
+    function scanLargeFiles(done) {
+        var threshold = Math.max(1, parseInt(root.largeFileThresholdMb) || 100);
+        var paths = normalizeSearchPaths();
+        var exclusionRegexes = parseExclusionRegexes();
+        var aggregated = [];
+        var steps = [];
+
+        for (var i = 0; i < paths.length; i++) {
+            (function(searchPath) {
+                steps.push(function(next) {
+                    if (!safeHomePath(searchPath)) {
+                        next();
+                        return;
+                    }
+                    var cmd = "find " + shellQuote(searchPath) + " -type f -size +" + threshold + "M -printf '%s|%T@|%p\\n' 2>/dev/null";
+                    run(cmd, function(out) {
+                        var lines = String(out).split("\n");
+                        for (var j = 0; j < lines.length; j++) {
+                            var line = lines[j].trim();
+                            if (!line) continue;
+                            var parts = line.split("|");
+                            if (parts.length < 3) continue;
+                            var filePath = parts.slice(2).join("|");
+                            if (!safeHomePath(filePath)) continue;
+                            if (isExcluded(filePath, exclusionRegexes)) continue;
+                            aggregated.push({
+                                size: parseNumber(parts[0]),
+                                mtime: parseFloat(parts[1]) || 0,
+                                path: filePath
+                            });
+                        }
+                        next();
+                    });
+                });
+            })(paths[i]);
+        }
+
+        runSequence(steps, function() {
+            aggregated.sort(function(a, b) { return b.size - a.size; });
+            largeFiles = aggregated.slice(0, 300);
+            if (done) done();
+        });
+    }
+
+    function summarizeCategoryForPath(pathValue) {
+        var p = String(pathValue || "").toLowerCase();
+        if (p.indexOf("/videos") >= 0 || p.indexOf("/video") >= 0
+            || p.indexOf("/music") >= 0 || p.indexOf("/pictures") >= 0
+            || p.indexOf("/photos") >= 0 || p.indexOf("/images") >= 0) {
+            return "Media";
+        }
+        if (p.indexOf("/documents") >= 0 || p.indexOf("/document") >= 0
+            || p.indexOf("/books") >= 0 || p.indexOf("/notes") >= 0) {
+            return "Documents";
+        }
+        if (p.indexOf("/downloads") >= 0 || p.indexOf("/archive") >= 0
+            || p.indexOf("/backup") >= 0) {
+            return "Archives";
+        }
+        if (p.indexOf("/projects") >= 0 || p.indexOf("/code") >= 0
+            || p.indexOf("/src") >= 0 || p.indexOf("/dev") >= 0) {
+            return "Code";
+        }
+        return "Other";
+    }
+
+    function scanDiskUsage(done) {
+        var paths = normalizePaths(root.diskAnalyzerPaths, [root.homeDir + "/Downloads", root.homeDir + "/Documents", root.homeDir + "/Videos", root.homeDir + "/Pictures"]);
+        var rows = [];
+        var steps = [];
+        var bucketMap = {};
+
+        for (var i = 0; i < paths.length; i++) {
+            (function(searchPath) {
+                steps.push(function(next) {
+                    if (!safeHomePath(searchPath)) {
+                        next();
+                        return;
+                    }
+                    var cmd = "find " + shellQuote(searchPath) + " -mindepth 1 -maxdepth 1 -print0 2>/dev/null | du --files0-from=- -sb 2>/dev/null";
+                    run(cmd, function(out) {
+                        var lines = String(out).split("\n");
+                        var hasRows = false;
+                        for (var j = 0; j < lines.length; j++) {
+                            var line = lines[j].trim();
+                            if (!line) continue;
+                            var parts = line.split(/\t+/);
+                            if (parts.length < 2) continue;
+                            var itemPath = parts.slice(1).join("\t");
+                            var itemSize = parseNumber(parts[0]);
+                            if (!safeHomePath(itemPath) || itemSize <= 0) continue;
+                            hasRows = true;
+                            rows.push({
+                                path: itemPath,
+                                size: itemSize,
+                                label: itemPath.split("/").pop()
+                            });
+                            var key = summarizeCategoryForPath(itemPath);
+                            bucketMap[key] = (bucketMap[key] || 0) + itemSize;
+                        }
+
+                        if (!hasRows) {
+                            run("du -sb " + shellQuote(searchPath) + " 2>/dev/null | awk '{print $1\"\\t\"$2}'", function(singleOut) {
+                                var singleParts = String(singleOut).trim().split(/\t+/);
+                                if (singleParts.length >= 2) {
+                                    var onePath = singleParts.slice(1).join("\t");
+                                    var oneSize = parseNumber(singleParts[0]);
+                                    if (safeHomePath(onePath) && oneSize > 0) {
+                                        rows.push({
+                                            path: onePath,
+                                            size: oneSize,
+                                            label: onePath.split("/").pop()
+                                        });
+                                        var oneKey = summarizeCategoryForPath(onePath);
+                                        bucketMap[oneKey] = (bucketMap[oneKey] || 0) + oneSize;
+                                    }
+                                }
+                                next();
+                            });
+                            return;
+                        }
+                        next();
+                    });
+                });
+            })(paths[i]);
+        }
+
+        runSequence(steps, function() {
+            rows.sort(function(a, b) { return b.size - a.size; });
+            diskTopDirs = rows.slice(0, 20);
+            diskTotalBytes = 0;
+            for (var k = 0; k < rows.length; k++) {
+                diskTotalBytes += rows[k].size;
+            }
+            var bucketRows = [];
+            for (var name in bucketMap) {
+                bucketRows.push({ name: name, size: bucketMap[name] });
+            }
+            bucketRows.sort(function(a, b) { return b.size - a.size; });
+            diskCategoryBuckets = bucketRows;
+            if (done) done();
+        });
+    }
+
+    function cleanNow() {
+        if (running) return;
+        running = true;
+        statusText = "Running cleanup";
+        var before = totalCleanupBytes;
+        var steps = [];
+
+        if (cleanupCache) {
+            steps.push(function(next) {
+                // Keep browser caches separate under cleanupBrowserCache toggle.
+                var cmd = "if [ -d \"$HOME/.cache\" ]; then find \"$HOME/.cache\" -mindepth 1 -maxdepth 1 ! -name 'mozilla' ! -name 'google-chrome' ! -name 'chromium' -exec rm -rf -- {} + 2>/dev/null; fi";
+                run(cmd, function() { next(); });
+            });
+        }
+
+        if (cleanupTrash) {
+            steps.push(function(next) {
+                var cmd = "rm -rf \"$HOME/.local/share/Trash/files\"/* \"$HOME/.local/share/Trash/info\"/* 2>/dev/null || true";
+                run(cmd, function() { next(); });
+            });
+        }
+
+        if (cleanupBrowserCache) {
+            steps.push(function(next) {
+                var cmd = "rm -rf \"$HOME/.cache/mozilla\" \"$HOME/.cache/google-chrome\" \"$HOME/.cache/chromium\" 2>/dev/null || true";
+                run(cmd, function() { next(); });
+            });
+        }
+
+        if (cleanupTmp) {
+            steps.push(function(next) {
+                var age = Math.max(1, parseInt(tmpAgeDays) || 3);
+                var cmd = "find /tmp -maxdepth 1 -user \"$USER\" -mtime +" + age + " -exec rm -rf -- {} + 2>/dev/null || true";
+                run(cmd, function() { next(); });
+            });
+        }
+
+        runSequence(steps, function() {
+            estimateCleanup(function() {
+                var reclaimed = Math.max(0, before - totalCleanupBytes);
+                lastCleanupBytes = reclaimed;
+                lastCleanupLabel = formatBytes(reclaimed);
+                scanLargeFiles(function() {
+                    scanDiskUsage(function() {
+                        running = false;
+                        statusText = "Cleanup completed";
+                    });
+                });
+            });
+        });
+    }
+
+    function removeLargeFile(pathValue) {
+        if (!safeHomePath(pathValue)) return;
+        if (running) return;
+        running = true;
+        statusText = "Deleting selected file";
+        var cmd = "rm -f -- " + shellQuote(pathValue) + " 2>/dev/null";
+        run(cmd, function() {
+            refreshAll();
+        });
+    }
+}

--- a/DankCleaner/DankCleaner.qml
+++ b/DankCleaner/DankCleaner.qml
@@ -1,0 +1,73 @@
+import QtQuick
+import qs.Common
+import qs.Widgets
+import qs.Modules.Plugins
+
+PluginComponent {
+    id: root
+
+    popoutWidth: 860
+    popoutHeight: 580
+
+    onPluginDataChanged: {
+        CleanerService.cleanupCache = pluginData.cleanupCache !== false;
+        CleanerService.cleanupTrash = pluginData.cleanupTrash !== false;
+        CleanerService.cleanupBrowserCache = pluginData.cleanupBrowserCache !== false;
+        CleanerService.cleanupTmp = pluginData.cleanupTmp === true;
+        CleanerService.tmpAgeDays = parseInt(pluginData.tmpAgeDays) || 3;
+        CleanerService.largeFileThresholdMb = parseInt(pluginData.largeFileThresholdMb) || 100;
+        CleanerService.largeFilePaths = pluginData.largeFilePaths || "~/Downloads\n~/Videos\n~/Documents";
+        CleanerService.diskAnalyzerPaths = pluginData.diskAnalyzerPaths || CleanerService.largeFilePaths;
+        CleanerService.excludePatterns = pluginData.excludePatterns || "";
+        CleanerService.refreshAll();
+    }
+
+    popoutContent: Component {
+        PopoutComponent {
+            DankCleanerPopout {
+                width: popoutWidth
+                height: popoutHeight - Theme.spacingS * 2
+            }
+        }
+    }
+
+    horizontalBarPill: Component {
+        Row {
+            spacing: Theme.spacingXS
+
+            DankIcon {
+                name: CleanerService.running ? "hourglass_top" : "cleaning_services"
+                color: CleanerService.running ? "#FF9800" : Theme.primary
+                size: root.iconSize
+                anchors.verticalCenter: parent.verticalCenter
+            }
+
+            StyledText {
+                anchors.verticalCenter: parent.verticalCenter
+                text: CleanerService.running ? "Scanning..." : CleanerService.totalCleanupLabel
+                color: Theme.surfaceText
+                font.pixelSize: Theme.fontSizeSmall
+            }
+        }
+    }
+
+    verticalBarPill: Component {
+        Column {
+            spacing: 2
+
+            DankIcon {
+                name: CleanerService.running ? "hourglass_top" : "cleaning_services"
+                color: CleanerService.running ? "#FF9800" : Theme.primary
+                size: root.iconSize
+                anchors.horizontalCenter: parent.horizontalCenter
+            }
+
+            StyledText {
+                anchors.horizontalCenter: parent.horizontalCenter
+                text: CleanerService.running ? "..." : CleanerService.totalCleanupShort
+                color: Theme.surfaceText
+                font.pixelSize: Theme.fontSizeXSmall
+            }
+        }
+    }
+}

--- a/DankCleaner/DankCleanerPopout.qml
+++ b/DankCleaner/DankCleanerPopout.qml
@@ -1,0 +1,542 @@
+import QtQuick
+import QtQuick.Layouts
+import qs.Common
+import qs.Widgets
+
+Column {
+    id: root
+    spacing: Theme.spacingM
+
+    function maxDiskRowSize() {
+        var rows = CleanerService.diskTopDirs || [];
+        if (rows.length === 0) return 1;
+        var maxV = rows[0].size || 1;
+        return Math.max(1, maxV);
+    }
+
+    function pieColor(index) {
+        var palette = [
+            Theme.primary,
+            "#4CAF50",
+            "#FF9800",
+            "#03A9F4",
+            "#AB47BC",
+            "#EF5350"
+        ];
+        return palette[index % palette.length];
+    }
+
+    DankTabBar {
+        id: tabBar
+        width: parent.width - Theme.spacingM * 2
+        anchors.horizontalCenter: parent.horizontalCenter
+        currentIndex: 0
+        model: [
+            { text: "Cleanup", icon: "cleaning_services" },
+            { text: "Large Files", icon: "folder_open" },
+            { text: "Disk Analyzer", icon: "pie_chart" }
+        ]
+        onTabClicked: function(index) { tabBar.currentIndex = index; }
+    }
+
+    Item {
+        visible: tabBar.currentIndex === 0
+        width: parent.width
+        height: parent.height - tabBar.height - Theme.spacingM * 2
+
+        Column {
+            anchors.fill: parent
+            anchors.margins: Theme.spacingM
+            spacing: Theme.spacingM
+
+            Rectangle {
+                width: parent.width
+                height: 72
+                radius: Theme.cornerRadius
+                color: Theme.surfaceContainerHigh
+
+                Row {
+                    anchors.fill: parent
+                    anchors.margins: Theme.spacingM
+                    spacing: Theme.spacingM
+
+                    Column {
+                        width: parent.width - cleanButton.width - Theme.spacingM
+                        anchors.verticalCenter: parent.verticalCenter
+                        spacing: 4
+
+                        StyledText {
+                            text: "Reclaimable space: " + CleanerService.formatBytes(CleanerService.totalCleanupBytes)
+                            font.pixelSize: Theme.fontSizeMedium
+                            font.weight: Font.DemiBold
+                            color: Theme.surfaceText
+                            width: parent.width
+                            elide: Text.ElideRight
+                        }
+
+                        StyledText {
+                            text: CleanerService.statusText + " • Last clean: " + CleanerService.lastCleanupLabel
+                            font.pixelSize: Theme.fontSizeSmall
+                            color: Theme.surfaceVariantText
+                            width: parent.width
+                            elide: Text.ElideRight
+                        }
+                    }
+
+                    DankButton {
+                        id: cleanButton
+                        text: CleanerService.running ? "Working..." : "Clean Now"
+                        iconName: "auto_fix_high"
+                        enabled: !CleanerService.running
+                        anchors.verticalCenter: parent.verticalCenter
+                        onClicked: CleanerService.cleanNow()
+                    }
+                }
+            }
+
+            GridLayout {
+                width: parent.width
+                columns: 2
+                columnSpacing: Theme.spacingM
+                rowSpacing: Theme.spacingM
+
+                Repeater {
+                    model: [
+                        {
+                            label: "User Cache",
+                            enabled: CleanerService.cleanupCache,
+                            value: CleanerService.cacheBytes
+                        },
+                        {
+                            label: "Trash",
+                            enabled: CleanerService.cleanupTrash,
+                            value: CleanerService.trashBytes
+                        },
+                        {
+                            label: "Browser Cache",
+                            enabled: CleanerService.cleanupBrowserCache,
+                            value: CleanerService.browserCacheBytes
+                        },
+                        {
+                            label: "Old /tmp (user only)",
+                            enabled: CleanerService.cleanupTmp,
+                            value: CleanerService.tmpBytes
+                        }
+                    ]
+
+                    Rectangle {
+                        required property var modelData
+                        Layout.fillWidth: true
+                        height: 84
+                        radius: Theme.cornerRadius
+                        color: Theme.surfaceContainerHigh
+
+                        Column {
+                            anchors.fill: parent
+                            anchors.margins: Theme.spacingM
+                            spacing: Theme.spacingXS
+
+                            StyledText {
+                                text: modelData.label
+                                font.pixelSize: Theme.fontSizeSmall
+                                color: Theme.surfaceVariantText
+                            }
+
+                            StyledText {
+                                text: CleanerService.formatBytes(modelData.value)
+                                font.pixelSize: Theme.fontSizeLarge
+                                font.weight: Font.Bold
+                                color: modelData.enabled ? Theme.primary : Theme.surfaceVariantText
+                            }
+
+                            StyledText {
+                                text: modelData.enabled ? "Enabled" : "Disabled"
+                                font.pixelSize: Theme.fontSizeSmall
+                                color: modelData.enabled ? Theme.primary : Theme.surfaceVariantText
+                            }
+                        }
+                    }
+                }
+            }
+
+            Row {
+                width: parent.width
+                spacing: Theme.spacingS
+
+                DankButton {
+                    text: "Rescan"
+                    iconName: "refresh"
+                    enabled: !CleanerService.running
+                    onClicked: CleanerService.refreshAll()
+                }
+
+                StyledText {
+                    anchors.verticalCenter: parent.verticalCenter
+                    text: "Safe mode: only user-space cache/temp/trash paths are touched."
+                    font.pixelSize: Theme.fontSizeSmall
+                    color: Theme.surfaceVariantText
+                    width: parent.width - 140
+                    elide: Text.ElideRight
+                }
+            }
+        }
+    }
+
+    Item {
+        visible: tabBar.currentIndex === 1
+        width: parent.width
+        height: parent.height - tabBar.height - Theme.spacingM * 2
+
+        Column {
+            anchors.fill: parent
+            anchors.margins: Theme.spacingM
+            spacing: Theme.spacingS
+
+            Row {
+                width: parent.width
+                spacing: Theme.spacingM
+
+                StyledText {
+                    text: "Large files (" + CleanerService.largeFiles.length + ")"
+                    font.pixelSize: Theme.fontSizeMedium
+                    font.weight: Font.DemiBold
+                    color: Theme.surfaceText
+                }
+
+                StyledText {
+                    text: "Threshold: " + CleanerService.largeFileThresholdMb + " MB"
+                    font.pixelSize: Theme.fontSizeSmall
+                    color: Theme.surfaceVariantText
+                    anchors.verticalCenter: parent.verticalCenter
+                }
+            }
+
+            Rectangle {
+                width: parent.width
+                height: 1
+                color: Theme.surfaceVariant
+            }
+
+            Flickable {
+                width: parent.width
+                height: parent.height - 34
+                clip: true
+                contentHeight: filesColumn.implicitHeight
+
+                Column {
+                    id: filesColumn
+                    width: parent.width
+                    spacing: 4
+
+                    Repeater {
+                        model: CleanerService.largeFiles
+
+                        Rectangle {
+                            required property var modelData
+                            required property int index
+                            width: filesColumn.width
+                            height: 62
+                            radius: 6
+                            color: index % 2 === 0 ? "transparent" : Qt.rgba(Theme.surfaceVariant.r, Theme.surfaceVariant.g, Theme.surfaceVariant.b, 0.25)
+
+                            Row {
+                                anchors.fill: parent
+                                anchors.leftMargin: Theme.spacingS
+                                anchors.rightMargin: Theme.spacingS
+                                spacing: Theme.spacingM
+
+                                Column {
+                                    width: Math.max(
+                                        120,
+                                        parent.width
+                                        - sizeText.width
+                                        - deleteButton.width
+                                        - Theme.spacingM * 2
+                                    )
+                                    anchors.verticalCenter: parent.verticalCenter
+                                    spacing: 2
+
+                                    StyledText {
+                                        text: modelData.path
+                                        color: Theme.surfaceText
+                                        font.pixelSize: Theme.fontSizeSmall
+                                        elide: Text.ElideMiddle
+                                        width: parent.width
+                                    }
+
+                                    StyledText {
+                                        text: "Modified: " + new Date(modelData.mtime * 1000).toLocaleString()
+                                        color: Theme.surfaceVariantText
+                                        font.pixelSize: Theme.fontSizeXSmall
+                                        width: parent.width
+                                        elide: Text.ElideRight
+                                    }
+                                }
+
+                                StyledText {
+                                    id: sizeText
+                                    text: CleanerService.formatBytes(modelData.size)
+                                    anchors.verticalCenter: parent.verticalCenter
+                                    color: Theme.primary
+                                    font.pixelSize: Theme.fontSizeSmall
+                                    width: 70
+                                    horizontalAlignment: Text.AlignRight
+                                }
+
+                                DankButton {
+                                    id: deleteButton
+                                    text: "Delete"
+                                    iconName: "delete"
+                                    width: 92
+                                    anchors.verticalCenter: parent.verticalCenter
+                                    enabled: !CleanerService.running
+                                    onClicked: CleanerService.removeLargeFile(modelData.path)
+                                }
+                            }
+                        }
+                    }
+
+                    Rectangle {
+                        visible: CleanerService.largeFiles.length === 0
+                        width: parent.width
+                        height: 80
+                        color: "transparent"
+                        StyledText {
+                            anchors.centerIn: parent
+                            text: CleanerService.running ? "Scanning..." : "No large files found in selected folders."
+                            color: Theme.surfaceVariantText
+                            font.pixelSize: Theme.fontSizeSmall
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    Item {
+        visible: tabBar.currentIndex === 2
+        width: parent.width
+        height: parent.height - tabBar.height - Theme.spacingM * 2
+
+        Column {
+            anchors.fill: parent
+            anchors.margins: Theme.spacingM
+            spacing: Theme.spacingS
+
+            Row {
+                width: parent.width
+                spacing: Theme.spacingM
+
+                StyledText {
+                    text: "Disk usage: " + CleanerService.formatBytes(CleanerService.diskTotalBytes)
+                    font.pixelSize: Theme.fontSizeMedium
+                    font.weight: Font.DemiBold
+                    color: Theme.surfaceText
+                }
+
+                DankButton {
+                    text: "Analyze"
+                    iconName: "refresh"
+                    enabled: !CleanerService.running
+                    onClicked: CleanerService.scanDiskUsage()
+                }
+            }
+
+            Row {
+                width: parent.width
+                height: parent.height - 40
+                spacing: Theme.spacingM
+
+                Rectangle {
+                    width: parent.width * 0.62
+                    height: parent.height
+                    radius: Theme.cornerRadius
+                    color: Theme.surfaceContainerHigh
+
+                    Column {
+                        anchors.fill: parent
+                        anchors.margins: Theme.spacingM
+                        spacing: Theme.spacingXS
+
+                        StyledText {
+                            text: "Top directories"
+                            font.pixelSize: Theme.fontSizeSmall
+                            color: Theme.surfaceVariantText
+                        }
+
+                        Flickable {
+                            width: parent.width
+                            height: parent.height - 24
+                            contentHeight: diskBars.implicitHeight
+                            clip: true
+
+                            Column {
+                                id: diskBars
+                                width: parent.width
+                                spacing: Theme.spacingXS
+
+                                Repeater {
+                                    model: CleanerService.diskTopDirs
+
+                                    Column {
+                                        required property var modelData
+                                        width: diskBars.width
+                                        spacing: 2
+
+                                        StyledText {
+                                            width: parent.width
+                                            text: modelData.path
+                                            elide: Text.ElideMiddle
+                                            font.pixelSize: Theme.fontSizeXSmall
+                                            color: Theme.surfaceVariantText
+                                        }
+
+                                        Rectangle {
+                                            width: parent.width
+                                            height: 10
+                                            radius: 5
+                                            color: Theme.surfaceVariant
+
+                                            Rectangle {
+                                                width: Math.max(
+                                                    2,
+                                                    parent.width * (modelData.size / root.maxDiskRowSize())
+                                                )
+                                                height: parent.height
+                                                radius: parent.radius
+                                                color: Theme.primary
+                                            }
+                                        }
+
+                                        StyledText {
+                                            text: CleanerService.formatBytes(modelData.size)
+                                            font.pixelSize: Theme.fontSizeXSmall
+                                            color: Theme.surfaceText
+                                        }
+                                    }
+                                }
+
+                                Rectangle {
+                                    visible: CleanerService.diskTopDirs.length === 0
+                                    width: parent.width
+                                    height: 80
+                                    color: "transparent"
+                                    StyledText {
+                                        anchors.centerIn: parent
+                                        text: CleanerService.running ? "Analyzing..." : "No disk data available."
+                                        color: Theme.surfaceVariantText
+                                        font.pixelSize: Theme.fontSizeSmall
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+
+                Rectangle {
+                    width: parent.width * 0.38 - Theme.spacingM
+                    height: parent.height
+                    radius: Theme.cornerRadius
+                    color: Theme.surfaceContainerHigh
+
+                    Column {
+                        anchors.fill: parent
+                        anchors.margins: Theme.spacingM
+                        spacing: Theme.spacingS
+
+                        StyledText {
+                            text: "Category split"
+                            font.pixelSize: Theme.fontSizeSmall
+                            color: Theme.surfaceVariantText
+                        }
+
+                        Canvas {
+                            id: pieCanvas
+                            width: Math.min(parent.width, 180)
+                            height: width
+                            anchors.horizontalCenter: parent.horizontalCenter
+
+                            onPaint: {
+                                var ctx = getContext("2d");
+                                ctx.clearRect(0, 0, width, height);
+                                var buckets = CleanerService.diskCategoryBuckets || [];
+                                var total = 0;
+                                for (var i = 0; i < buckets.length; i++) total += buckets[i].size;
+                                if (total <= 0) return;
+
+                                var cx = width / 2;
+                                var cy = height / 2;
+                                var r = Math.min(cx, cy) - 4;
+                                var start = -Math.PI / 2;
+
+                                for (var j = 0; j < buckets.length; j++) {
+                                    var part = buckets[j].size / total;
+                                    var end = start + (Math.PI * 2 * part);
+                                    ctx.beginPath();
+                                    ctx.moveTo(cx, cy);
+                                    ctx.arc(cx, cy, r, start, end, false);
+                                    ctx.closePath();
+                                    ctx.fillStyle = root.pieColor(j);
+                                    ctx.fill();
+                                    start = end;
+                                }
+
+                                ctx.beginPath();
+                                ctx.arc(cx, cy, r * 0.5, 0, Math.PI * 2, false);
+                                ctx.fillStyle = Theme.surfaceContainerHigh;
+                                ctx.fill();
+                            }
+
+                            Connections {
+                                target: CleanerService
+                                function onDiskCategoryBucketsChanged() {
+                                    pieCanvas.requestPaint();
+                                }
+                            }
+                        }
+
+                        Flickable {
+                            width: parent.width
+                            height: parent.height - pieCanvas.height - 56
+                            contentHeight: legendColumn.implicitHeight
+                            clip: true
+
+                            Column {
+                                id: legendColumn
+                                width: parent.width
+                                spacing: Theme.spacingXS
+
+                                Repeater {
+                                    model: CleanerService.diskCategoryBuckets
+                                    Row {
+                                        required property var modelData
+                                        required property int index
+                                        width: legendColumn.width
+                                        spacing: Theme.spacingXS
+
+                                        Rectangle {
+                                            width: 10
+                                            height: 10
+                                            radius: 5
+                                            color: root.pieColor(index)
+                                            anchors.verticalCenter: parent.verticalCenter
+                                        }
+
+                                        StyledText {
+                                            width: parent.width - 16
+                                            text: modelData.name + " • " + CleanerService.formatBytes(modelData.size)
+                                            elide: Text.ElideRight
+                                            font.pixelSize: Theme.fontSizeXSmall
+                                            color: Theme.surfaceText
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+}

--- a/DankCleaner/DankCleanerSettings.qml
+++ b/DankCleaner/DankCleanerSettings.qml
@@ -1,0 +1,156 @@
+import QtQuick
+import qs.Common
+import qs.Widgets
+import qs.Modules.Plugins
+
+PluginSettings {
+    id: root
+    pluginId: "dankCleaner"
+
+    StyledText {
+        width: parent.width
+        text: "Dank Cleaner Settings"
+        font.pixelSize: Theme.fontSizeLarge
+        font.weight: Font.Bold
+        color: Theme.surfaceText
+    }
+
+    StyledText {
+        width: parent.width
+        text: "Safe mode cleaner: user cache, trash, browser cache, and optional old /tmp files."
+        wrapMode: Text.WordWrap
+        font.pixelSize: Theme.fontSizeSmall
+        color: Theme.surfaceVariantText
+    }
+
+    StyledRect {
+        width: parent.width
+        height: cleanupColumn.implicitHeight + Theme.spacingL * 2
+        radius: Theme.cornerRadius
+        color: Theme.surfaceContainerHigh
+
+        Column {
+            id: cleanupColumn
+            anchors.fill: parent
+            anchors.margins: Theme.spacingL
+            spacing: Theme.spacingM
+
+            StyledText {
+                text: "Cleanup Categories"
+                font.pixelSize: Theme.fontSizeMedium
+                color: Theme.surfaceText
+                font.weight: Font.Medium
+            }
+
+            ToggleSetting {
+                settingKey: "cleanupCache"
+                label: "Clean ~/.cache"
+                description: "Remove cache files from your home cache directory"
+                defaultValue: true
+            }
+
+            ToggleSetting {
+                settingKey: "cleanupTrash"
+                label: "Clean Trash"
+                description: "Empty ~/.local/share/Trash/files and info"
+                defaultValue: true
+            }
+
+            ToggleSetting {
+                settingKey: "cleanupBrowserCache"
+                label: "Clean browser cache"
+                description: "Cleans mozilla/chrome/chromium cache directories if present"
+                defaultValue: true
+            }
+
+            ToggleSetting {
+                settingKey: "cleanupTmp"
+                label: "Clean old /tmp files (user-owned only)"
+                description: "Only removes /tmp entries owned by your user and older than threshold"
+                defaultValue: false
+            }
+
+            StringSetting {
+                settingKey: "tmpAgeDays"
+                label: "Age threshold for /tmp (days)"
+                description: "Files older than this are eligible for cleanup"
+                placeholder: "3"
+                defaultValue: "3"
+            }
+        }
+    }
+
+    StyledRect {
+        width: parent.width
+        height: largeFilesColumn.implicitHeight + Theme.spacingL * 2
+        radius: Theme.cornerRadius
+        color: Theme.surfaceContainerHigh
+
+        Column {
+            id: largeFilesColumn
+            anchors.fill: parent
+            anchors.margins: Theme.spacingL
+            spacing: Theme.spacingM
+
+            StyledText {
+                text: "Large File Scanner"
+                font.pixelSize: Theme.fontSizeMedium
+                color: Theme.surfaceText
+                font.weight: Font.Medium
+            }
+
+            StringSetting {
+                settingKey: "largeFileThresholdMb"
+                label: "Large file threshold (MB)"
+                description: "Only files bigger than this size are shown"
+                placeholder: "100"
+                defaultValue: "100"
+            }
+
+            StringSetting {
+                settingKey: "largeFilePaths"
+                label: "Scan paths (comma or newline separated)"
+                description: "Use home paths only, e.g. ~/Downloads, ~/Videos"
+                placeholder: "~/Downloads,~/Videos,~/Documents"
+                defaultValue: "~/Downloads\n~/Videos\n~/Documents"
+            }
+
+            StringSetting {
+                settingKey: "excludePatterns"
+                label: "Exclude patterns (* and ? supported)"
+                description: "Example: ~/Downloads/keep/*"
+                placeholder: ""
+                defaultValue: ""
+            }
+        }
+    }
+
+    StyledRect {
+        width: parent.width
+        height: analysisColumn.implicitHeight + Theme.spacingL * 2
+        radius: Theme.cornerRadius
+        color: Theme.surfaceContainerHigh
+
+        Column {
+            id: analysisColumn
+            anchors.fill: parent
+            anchors.margins: Theme.spacingL
+            spacing: Theme.spacingM
+
+            StyledText {
+                text: "Disk Analyzer"
+                font.pixelSize: Theme.fontSizeMedium
+                color: Theme.surfaceText
+                font.weight: Font.Medium
+            }
+
+            StringSetting {
+                settingKey: "diskAnalyzerPaths"
+                label: "Disk analyzer paths"
+                description: "Top-level usage chart source paths (home folder only)"
+                placeholder: "~/Downloads,~/Documents,~/Videos,~/Pictures"
+                defaultValue: "~/Downloads\n~/Documents\n~/Videos\n~/Pictures"
+            }
+        }
+    }
+}

--- a/DankCleaner/README.md
+++ b/DankCleaner/README.md
@@ -1,0 +1,27 @@
+# Dank Cleaner
+
+Safe one-click cleaner plugin for DankMaterialShell.
+
+## Features
+
+- One-click cleanup for safe user-space junk categories
+- Reclaimable space estimation before cleanup
+- Large file discovery view with configurable threshold
+- Disk analyzer tab with top-directory bars and category split
+- Optional per-file delete action in large-file results
+
+## Safe Mode Scope
+
+Default cleanup targets:
+
+- `~/.cache` (excluding browser cache directories by default)
+- `~/.local/share/Trash/files` and `~/.local/share/Trash/info`
+- Browser cache folders (if present): `~/.cache/mozilla`, `~/.cache/google-chrome`, `~/.cache/chromium`
+- Optional old `/tmp` files owned by current user only
+
+The plugin does not clean system package caches or privileged paths.
+
+## Development
+
+- Main branch contains stable plugin code.
+- Use short-lived feature branches and open PRs into `main`.

--- a/DankCleaner/plugin.json
+++ b/DankCleaner/plugin.json
@@ -1,0 +1,30 @@
+{
+    "$schema": "https://github.com/AvengeMedia/DankMaterialShell/raw/refs/heads/master/PLUGINS/plugin-schema.json",
+    "id": "dankCleaner",
+    "name": "Dank Cleaner",
+    "description": "One-click safe cleaner with junk scan and large file discovery.",
+    "version": "1.0.0",
+    "author": "noxius",
+    "icon": "cleaning_services",
+    "type": "widget",
+    "capabilities": [
+        "safe-cleanup",
+        "large-file-scan",
+        "disk-analyzer"
+    ],
+    "component": "./DankCleaner.qml",
+    "settings": "./DankCleanerSettings.qml",
+    "requires_dms": ">=1.4.0",
+    "requires": [
+        "bash",
+        "find",
+        "du",
+        "awk",
+        "tail",
+        "rm"
+    ],
+    "permissions": [
+        "settings_read",
+        "settings_write"
+    ]
+}

--- a/DankCleaner/qmldir
+++ b/DankCleaner/qmldir
@@ -1,0 +1,1 @@
+singleton CleanerService 1.0 CleanerService.qml

--- a/README.md
+++ b/README.md
@@ -29,3 +29,9 @@ Trigger scripts based on various system events, such as `onWallpaperChanged`, `o
 Trigger notifications when battery reaches low charge levels.
 
 <img width="497" height="710" alt="image" src="https://github.com/user-attachments/assets/4302d886-eb87-41d4-a9a4-1eeaadd787c6" />
+
+### [Dank Cleaner](./DankCleaner)
+
+One-click safe cleaner with junk cleanup, large-file discovery, and disk analyzer visuals.
+
+Default scope is user-space only (`~/.cache`, trash, optional old `/tmp` entries owned by current user).


### PR DESCRIPTION
## Summary
- add a new `DankCleaner` plugin directory with widget, popout, settings, service, manifest, and qmldir
- include safe user-space cleanup, large-file discovery, and disk-analyzer UI
- update plugin collection README with a `Dank Cleaner` entry

## Test plan
- [x] Validate plugin files are present under `DankCleaner/`
- [x] Verify `plugin.json` points to component/settings and uses `dankCleaner` id
- [x] Run local lint diagnostics on plugin files (no errors)