### PR TITLE
Add a hook for when the DankHooks plugins starts

### DIFF
--- a/DankHooks/DankHooks.qml
+++ b/DankHooks/DankHooks.qml
@@ -7,8 +7,10 @@ import qs.Modules.Plugins
 PluginComponent {
     id: root
 
+    signal dankHooksStarted
     property bool preparingForSleep: false
 
+    property string hookDankHooksStarted: pluginData.dankHooksStarted || ""
     property string hookWallpaperPath: pluginData.wallpaperPath || ""
     property string hookLightMode: pluginData.lightMode || ""
     property string hookTheme: pluginData.theme || ""
@@ -36,6 +38,21 @@ PluginComponent {
     property string hookMonitorWallpaper: pluginData.monitorWallpaper || ""
     property string hookSessionLocked: pluginData.sessionLocked || ""
     property string hookSessionUnlocked: pluginData.sessionUnlocked || ""
+
+    Connections {
+        function onDankHooksStarted() {
+            if (!pluginData.dankHooksStarted)
+                return;
+            if (!hookDankHooksStarted)
+                hookDankHooksStarted = pluginData.dankHooksStarted || "";
+            if (hookDankHooksStarted) {
+                const first_start = PluginService.getGlobalVar("dankHooks", "first_start", true);
+                executeHook(hookDankHooksStarted, "onDankHooksStarted", first_start ? "started" : "restarted");
+                if (first_start)
+                    PluginService.setGlobalVar("dankHooks", "first_start", false);
+            }
+        }
+    }
 
     Connections {
         target: SessionData
@@ -294,6 +311,11 @@ PluginComponent {
                 destroy();
             }
         }
+    }
+
+    onPluginDataChanged: {
+        if (pluginData)
+            dankHooksStarted();
     }
 
     Component.onDestruction: {

--- a/DankHooks/DankHooksSettings.qml
+++ b/DankHooks/DankHooksSettings.qml
@@ -301,6 +301,14 @@ PluginSettings {
     }
 
     StringSetting {
+        settingKey: "dankHooksStarted"
+        label: "Dank Hooks Started"
+        description: "Hook: onDankHooksStarted | Value: 'started' or 'restarted'"
+        placeholder: "/path/to/dankhooks-hook.sh"
+        defaultValue: ""
+    }
+
+    StringSetting {
         settingKey: "doNotDisturb"
         label: "Do Not Disturb Changed"
         description: "Hook: onDoNotDisturbChanged | Value: 'enabled' or 'disabled'"

--- a/DankHooks/plugin.json
+++ b/DankHooks/plugin.json
@@ -2,7 +2,7 @@
     "id": "dankHooks",
     "name": "Dank Hooks",
     "description": "Execute custom scripts on system events like wallpaper changes, theme updates, battery level changes, and more",
-    "version": "1.0.8",
+    "version": "1.0.9",
     "license": "MIT",
     "author": "Avenge Media",
     "icon": "webhook",


### PR DESCRIPTION
This will allow users to run a script when DankHooks starts or restarts. It affectively lets users run a script when DMS itself starts

I am using onPluginDataChanged to wait for pluginData to be available before triggering the hook