### PR TITLE
[KDEConnect] Auto-refresh status every minute

### DIFF
--- a/DankKDEConnect/services/KDEConnectService.qml
+++ b/DankKDEConnect/services/KDEConnectService.qml
@@ -642,4 +642,11 @@ Singleton {
             return "battery_1_bar";
         return "battery_alert";
     }
+
+    Timer {
+      interval: 60 * 1000
+      running: true
+      repeat: true
+      onTriggered: refreshDevices()
+    }
 }


### PR DESCRIPTION
This PR adds a timer which automatically refreshes the status of connected devices once every minute.

Currently, if you show your phone's battery status in the bar, it will only update the current charge when you manually click to refresh.

I tried to make this configurable, but with the component being a `Singleton` rather than a `PluginComponent` I don't see how to access `pluginData`. If you have suggestions for how to improve this PR, I would be happy to add them!