### PR TITLE
Pomodoro : Time format + icons

### DIFF
--- a/DankPomodoroTimer/DankPomodoroWidget.qml
+++ b/DankPomodoroTimer/DankPomodoroWidget.qml
@@ -267,7 +267,7 @@ PluginComponent {
     function formatTime(seconds, isVertical = false) {
         const mins = Math.floor(seconds / 60)
         const secs = seconds % 60
-        return isVertical ? mins + "\n" + (secs < 10 ? "0" : "") + secs : mins + " " + (secs < 10 ? "0" : "") + secs
+        return isVertical ? mins + "\n" + (secs < 10 ? "0" : "") + secs : mins + ":" + (secs < 10 ? "0" : "") + secs
     }
 
     function getStateColor() {
@@ -281,6 +281,8 @@ PluginComponent {
     function getStateIcon() {
         if (globalTimerState.value === "work")
             return "work"
+        if (globalTimerState.value === "longBreak")
+            return "weekend"
         return "coffee"
     }
 


### PR DESCRIPTION
Reintroduce colon separator and add longBreak icon

## Colon separator
<img width="319" height="355" alt="image" src="https://github.com/user-attachments/assets/1e2970f1-378f-400c-ba7f-fca2a48dad41" />

## Long breakk icon in status bar
<img width="105" height="40" alt="image" src="https://github.com/user-attachments/assets/9f1a21bd-f628-42a0-a031-3df9cc1cc2c8" />
