### PR TITLE
fix hyprland lua window close IPC in DankHyprlandWindows

### DIFF
--- a/DankHyprlandWindows/DankHyprlandWindows.qml
+++ b/DankHyprlandWindows/DankHyprlandWindows.qml
@@ -72,7 +72,7 @@ QtObject {
         if (Hyprland.usingLua === false)
             Hyprland.dispatch(`closewindow ${selector}`);
         else
-            Hyprland.dispatch(`hl.dsp.window.close("${selector}")`);
+            Hyprland.dispatch(`hl.dsp.window.close({window = "${selector}"})`);
     }
 
     function getItems(query) {


### PR DESCRIPTION
as existing, this doesn't target anything with the provided selector and thus just closes the focused window.