### PR TITLE
DankKDEConnect: fix last device clipped in control center detail

### DIFF
--- a/DankKDEConnect/DankKDEConnect.qml
+++ b/DankKDEConnect/DankKDEConnect.qml
@@ -45,9 +45,7 @@ PluginComponent {
     onCcWidgetExpanded: PhoneConnectService.detectBackend()
 
     ccDetailContent: Component {
-        KDEConnectDetailContent {
-            listHeight: 300
-        }
+        KDEConnectDetailContent {}
     }
 
     onPluginServiceChanged: {

--- a/DankKDEConnect/components/KDEConnectDetailContent.qml
+++ b/DankKDEConnect/components/KDEConnectDetailContent.qml
@@ -9,7 +9,6 @@ Rectangle {
     id: root
 
     property var parentPopout: null
-    property int listHeight: 280
     property string shareDeviceId: ""
 
     implicitHeight: contentColumn.implicitHeight + Theme.spacingM * 2
@@ -25,6 +24,7 @@ Rectangle {
         spacing: Theme.spacingS
 
         RowLayout {
+            id: headerRow
             spacing: Theme.spacingS
             width: parent.width
 
@@ -72,6 +72,7 @@ Rectangle {
         }
 
         Rectangle {
+            id: dividerLine
             height: 1
             width: parent.width
             color: Qt.rgba(Theme.outline.r, Theme.outline.g, Theme.outline.b, 0.12)
@@ -79,7 +80,7 @@ Rectangle {
 
         Item {
             width: parent.width
-            height: root.listHeight
+            height: Math.max(0, root.height - headerRow.height - dividerLine.height - Theme.spacingS * 2 - Theme.spacingM * 2)
 
             Column {
                 anchors.centerIn: parent


### PR DESCRIPTION
The control center host sizes the plugin detail panel to ccDetailHeight (350) minus spacing, but KDEConnectDetailContent used a hardcoded 300px list area below a header, divider, and margins. The combined height overflowed the allocated panel, clipping the bottom of the last device entry and making it unclickable when scrolled to the bottom.

Size the list area from the rectangle's actual height (driven by the host loader) instead of a fixed value, and drop the now-unused listHeight property.