### PR TITLE
DankKDEConnect: scale bar icon with DMS iconSize setting

### DIFF
--- a/DankKDEConnect/DankKDEConnect.qml
+++ b/DankKDEConnect/DankKDEConnect.qml
@@ -194,7 +194,7 @@ PluginComponent {
                 DankIcon {
                     id: phoneIcon
                     name: root.hasDevice && root.selectedDevice.isReachable ? "smartphone" : "phonelink_off"
-                    size: Theme.barIconSize(root.barThickness, -4)
+                    size: root.iconSizeLarge
                     color: {
                         if (!PhoneConnectService.available)
                             return Theme.widgetIconColor;
@@ -246,7 +246,7 @@ PluginComponent {
                 DankIcon {
                     id: phoneIconV
                     name: root.hasDevice && root.selectedDevice.isReachable ? "smartphone" : "phonelink_off"
-                    size: Theme.barIconSize(root.barThickness)
+                    size: root.iconSizeLarge
                     color: {
                         if (!PhoneConnectService.available)
                             return Theme.widgetIconColor;

--- a/DankKDEConnect/plugin.json
+++ b/DankKDEConnect/plugin.json
@@ -2,7 +2,7 @@
     "id": "dankKDEConnect",
     "name": "Phone Connect",
     "description": "Control connected devices via KDE Connect or Valent - view battery, send files, find phone, and more",
-    "version": "2.0.4",
+    "version": "2.0.5",
     "license": "MIT",
     "author": "Avenge Media",
     "icon": "devices",


### PR DESCRIPTION
## Problem

The Phone Connect (DankKDEConnect) bar icon did not resize when adjusting the **bar icon size** setting in DMS settings. The icon stayed a fixed size regardless of the slider.

## Root cause

`Theme.barIconSize(barThickness, offset, maximizeIcon, iconScale)` takes the icon-resizer (`iconScale`) as its **4th argument**. The bar pills called it with only two arguments:

```qml
size: Theme.barIconSize(root.barThickness, -4)   // horizontal
size: Theme.barIconSize(root.barThickness)        // vertical
```

With `maximizeIcon` and `iconScale` omitted they defaulted to no-ops, so the resizer had no effect.

## Fix

Use the `iconSizeLarge` convenience property exposed by `PluginComponent` for both pills:

```qml
size: root.iconSizeLarge   // horizontal & vertical (offset -6)
```

`iconSizeLarge` pre-wires the `-6` offset together with `barConfig.maximizeWidgetIcons` and `barConfig.iconScale`, so the icon now follows the resizer. The `-6` offset renders at the same size as the majority of built-in bar widgets (Weather, CpuMonitor, RamMonitor, DiskUsage, etc. all use `-6`) and matches the icon+text widgets that pair an icon with a value, as this plugin does (battery `100%`). The secondary charging `bolt` badge already scales relative to `phoneIcon.size`, so it follows automatically.

Version bumped to 2.0.5.