### PR TITLE
feat(pomodoro): add icon-only mode

### DIFF
--- a/DankPomodoroTimer/DankPomodoroSettings.qml
+++ b/DankPomodoroTimer/DankPomodoroSettings.qml
@@ -109,6 +109,13 @@ PluginSettings {
                 description: "Automatically enable Do Not Disturb mode during work sessions"
                 defaultValue: false
             }
+
+            ToggleSetting {
+                settingKey: "showBarText"
+                label: "Show Timer Text in Bar"
+                description: "Show the remaining time next to the timer icon"
+                defaultValue: true
+            }
         }
     }
 

--- a/DankPomodoroTimer/DankPomodoroWidget.qml
+++ b/DankPomodoroTimer/DankPomodoroWidget.qml
@@ -15,6 +15,7 @@ PluginComponent {
     property bool autoStartBreaks: pluginData.autoStartBreaks ?? false
     property bool autoStartPomodoros: pluginData.autoStartPomodoros ?? false
     property bool autoSetDND: pluginData.autoSetDND ?? false
+    property bool showBarText: pluginData.showBarText ?? true
     property var last7DaysData: []
     property string currentDateKey: ""
 
@@ -344,6 +345,7 @@ PluginComponent {
                 font.weight: Font.Medium
                 color: Theme.surfaceVariantText
                 anchors.verticalCenter: parent.verticalCenter
+                visible: root.showBarText
             }
         }
     }
@@ -365,6 +367,7 @@ PluginComponent {
                 font.weight: Font.Medium
                 color: Theme.surfaceVariantText
                 anchors.horizontalCenter: parent.horizontalCenter
+                visible: root.showBarText
             }
         }
     }


### PR DESCRIPTION
Add a setting to hide the remaining-time text and keep only the Pomodoro icon in both bar orientations. Existing behavior remains unchanged by default.

<img width="997" height="597" alt="dms_capture_1786677738874" src="https://github.com/user-attachments/assets/caebee97-1a88-42e8-b823-db7202e00bc7" />
<img width="75" height="64" alt="image" src="https://github.com/user-attachments/assets/1b5686f3-b0f8-4b23-913c-da24349e3b83" />

Closes #71