### PR TITLE
feat(pomodoro): add completion sound

### DIFF
--- a/DankPomodoroTimer/DankPomodoroSettings.qml
+++ b/DankPomodoroTimer/DankPomodoroSettings.qml
@@ -109,6 +109,13 @@ PluginSettings {
                 description: "Automatically enable Do Not Disturb mode during work sessions"
                 defaultValue: false
             }
+
+            ToggleSetting {
+                settingKey: "playCompletionSound"
+                label: "Play Completion Sound"
+                description: "Play a sound when a work session or break ends"
+                defaultValue: true
+            }
         }
     }
 

--- a/DankPomodoroTimer/DankPomodoroWidget.qml
+++ b/DankPomodoroTimer/DankPomodoroWidget.qml
@@ -15,6 +15,7 @@ PluginComponent {
     property bool autoStartBreaks: pluginData.autoStartBreaks ?? false
     property bool autoStartPomodoros: pluginData.autoStartPomodoros ?? false
     property bool autoSetDND: pluginData.autoSetDND ?? false
+    property bool playCompletionSound: pluginData.playCompletionSound ?? true
     property var last7DaysData: []
     property string currentDateKey: ""
 
@@ -190,17 +191,23 @@ PluginComponent {
             }
             const isLongBreak = globalCompletedPomodoros.value % 4 === 0;
 
-            Quickshell.execDetached(["sh", "-c", "notify-send 'Pomodoro Complete' 'Time for a " + (isLongBreak ? "long" : "short") + " break!' -u normal"]);
-
+            // Stop DND before playing the completion sound so an automatically
+            // enabled work-session DND mode does not suppress the alert.
             if (root.autoSetDND) {
                 SessionData.setDoNotDisturb(false);
             }
+            if (root.playCompletionSound && SettingsData.soundsEnabled)
+                AudioService.playNormalNotificationSound();
+            Quickshell.execDetached(["sh", "-c", "notify-send 'Pomodoro Complete' 'Time for a " + (isLongBreak ? "long" : "short") + " break!' -u normal"]);
+
             if (isLongBreak) {
                 root.startLongBreak(root.autoStartBreaks);
             } else {
                 root.startShortBreak(root.autoStartBreaks);
             }
         } else {
+            if (root.playCompletionSound && SettingsData.soundsEnabled)
+                AudioService.playNormalNotificationSound();
             Quickshell.execDetached(["sh", "-c", "notify-send 'Break Complete' 'Ready for another pomodoro?' -u normal"]);
             root.startWork(root.autoStartPomodoros);
         }


### PR DESCRIPTION
Closes #57

Adds a per-plugin `Play Completion Sound` toggle, enabled by default. Completion playback respects the global DMS sound setting and avoids automatic work-session DND suppression.

Validation: `qmllint` and `git diff --check` pass.