### PR TITLE
fix(dankKDEConnect): prioritize auto-selecting online/reachable devices

### DIFF
--- a/DankKDEConnect/DankKDEConnect.qml
+++ b/DankKDEConnect/DankKDEConnect.qml
@@ -91,6 +91,7 @@ PluginComponent {
     onPopoutOpenChanged: {
         if (popoutOpen) {
             PhoneConnectService.refreshDevices();
+            root.autoSelectBestDevice();
         }
     }
 
@@ -571,15 +572,37 @@ PluginComponent {
         }
     }
 
+    function autoSelectBestDevice() {
+        const ids = PhoneConnectService.deviceIds;
+        if (ids.length === 0) {
+            selectDevice("");
+            return;
+        }
+
+        if (selectedDeviceId && ids.includes(selectedDeviceId)) {
+            const currentDev = PhoneConnectService.getDevice(selectedDeviceId);
+            if (currentDev && currentDev.isReachable) {
+                return;
+            }
+        }
+
+        for (let i = 0; i < ids.length; i++) {
+            const dev = PhoneConnectService.getDevice(ids[i]);
+            if (dev && dev.isReachable) {
+                selectDevice(ids[i]);
+                return;
+            }
+        }
+
+        if (!selectedDeviceId || !ids.includes(selectedDeviceId)) {
+            selectDevice(ids[0]);
+        }
+    }
+
     Connections {
         target: PhoneConnectService
         function onDevicesListChanged() {
-            const ids = PhoneConnectService.deviceIds;
-            if (ids.length === 0) {
-                selectDevice("");
-            } else if (!selectedDeviceId || !ids.includes(selectedDeviceId)) {
-                selectDevice(ids[0]);
-            }
+            root.autoSelectBestDevice();
         }
 
         function onPairingRequestReceived(deviceId, verificationKey) {

--- a/DankKDEConnect/DankKDEConnect.qml
+++ b/DankKDEConnect/DankKDEConnect.qml
@@ -605,6 +605,10 @@ PluginComponent {
             root.autoSelectBestDevice();
         }
 
+        function onDeviceUpdated(deviceId) {
+            root.autoSelectBestDevice();
+        }
+
         function onPairingRequestReceived(deviceId, verificationKey) {
             const device = PhoneConnectService.getDevice(deviceId);
             const msg = verificationKey ? (I18n.tr("Verification", "Phone Connect pairing verification key label") + ": " + verificationKey) : "";


### PR DESCRIPTION
### Problem
Currently, `DankKDEConnect` defaults to selecting `ids[0]` (the first paired device in the list) whenever the device list is refreshed or when no device is explicitly selected. If the first device in the list is offline while another paired device is online/connected, the plugin defaults to showing the offline device details instead of the connected device. Furthermore, device properties (such as `isReachable`) load asynchronously from DBus, which previously caused the topbar status icon to stay on an offline device until the popout was manually clicked.

### Solution
Introduced `autoSelectBestDevice()` helper function:
- If the currently selected device is valid and online (`isReachable`), keep the selection.
- If the current device is offline or unselected, scan for the first online/reachable device.
- Fall back to `ids[0]` if all devices are offline.
- Trigger `autoSelectBestDevice()` on `onDevicesListChanged`, `onDeviceUpdated` (to handle asynchronous DBus property loading on startup), and `onPopoutOpenChanged`.