### PR TITLE
feat(pomodoro): configure long breaks

### DIFF
--- a/DankPomodoroTimer/DankPomodoroSettings.qml
+++ b/DankPomodoroTimer/DankPomodoroSettings.qml
@@ -63,9 +63,18 @@ PluginSettings {
             StringSetting {
                 settingKey: "longBreakDuration"
                 label: "Long Break (minutes)"
-                description: "Break after 4 pomodoros"
+                description: "Length of the long break"
                 placeholder: "15"
                 defaultValue: "15"
+            }
+
+            SliderSetting {
+                settingKey: "longBreakFrequency"
+                label: "Long Break Frequency"
+                description: "Start a long break after this many pomodoros"
+                defaultValue: 4
+                minimum: 1
+                maximum: 12
             }
         }
     }
@@ -144,7 +153,7 @@ PluginSettings {
             }
 
             StyledText {
-                text: "The Pomodoro Technique uses 25-minute focused work sessions followed by short breaks. After 4 pomodoros, take a longer break to recharge.\n\n• Work: 25 minutes of focused work\n• Short Break: 5 minute rest\n• Long Break: 15 minutes after 4 pomodoros\n\nNotifications will alert you when each session completes."
+                text: "The Pomodoro Technique uses 25-minute focused work sessions followed by short breaks. After a configurable number of pomodoros, take a longer break to recharge.\n\n• Work: 25 minutes of focused work\n• Short Break: 5 minute rest\n• Long Break: 15 minute rest at the configured frequency\n\nNotifications will alert you when each session completes."
                 font.pixelSize: Theme.fontSizeSmall
                 color: Theme.surfaceVariantText
                 wrapMode: Text.WordWrap

--- a/DankPomodoroTimer/DankPomodoroWidget.qml
+++ b/DankPomodoroTimer/DankPomodoroWidget.qml
@@ -12,6 +12,10 @@ PluginComponent {
     property int workDuration: pluginData.workDuration || 25
     property int shortBreakDuration: pluginData.shortBreakDuration || 5
     property int longBreakDuration: pluginData.longBreakDuration || 15
+    property int longBreakFrequency: {
+        const configured = parseInt(pluginData.longBreakFrequency, 10)
+        return configured > 0 ? configured : 4
+    }
     property bool autoStartBreaks: pluginData.autoStartBreaks ?? false
     property bool autoStartPomodoros: pluginData.autoStartPomodoros ?? false
     property bool autoSetDND: pluginData.autoSetDND ?? false
@@ -188,7 +192,7 @@ PluginComponent {
                 pluginService.savePluginState("dankPomodoroTimer", "completedPomodoros-" + dateKey, globalCompletedPomodoros.value);
                 loadLast7Days();
             }
-            const isLongBreak = globalCompletedPomodoros.value % 4 === 0;
+            const isLongBreak = globalCompletedPomodoros.value % root.longBreakFrequency === 0;
 
             Quickshell.execDetached(["sh", "-c", "notify-send 'Pomodoro Complete' 'Time for a " + (isLongBreak ? "long" : "short") + " break!' -u normal"]);
 
@@ -581,7 +585,7 @@ PluginComponent {
                         }
 
                         StyledText {
-                            text: "Next long break after " + (4 - (globalCompletedPomodoros.value % 4)) + " more"
+                            text: "Next long break after " + (root.longBreakFrequency - (globalCompletedPomodoros.value % root.longBreakFrequency)) + " more"
                             font.pixelSize: Theme.fontSizeSmall
                             color: Theme.surfaceVariantText
                             leftPadding: Theme.iconSize + Theme.spacingM


### PR DESCRIPTION
Closes #36

Adds a 1–12 slider for long-break frequency, defaulting to 4 pomodoros. Runtime validation falls back to 4 for invalid legacy values, and the next-break status text uses the configured frequency.

Validation: `qmllint` and `git diff --check` pass.