### PR TITLE
DankKDEConnect: don't lose saved device selection on startup/transient gaps

### DIFF
--- a/DankKDEConnect/DankKDEConnect.qml
+++ b/DankKDEConnect/DankKDEConnect.qml
@@ -492,12 +492,21 @@ PluginComponent {
         }
     }
 
+    // True once we've authoritatively confirmed the persisted selection via
+    // pluginService (which loads from disk on the backend side). Before this,
+    // `selectedDeviceId` may still read "" simply because SettingsData hasn't
+    // finished loading yet, not because nothing was ever selected - so device
+    // list events arriving before this is true must not be treated as
+    // "no preference" and must not overwrite/clobber the saved device.
+    property bool settingsLoaded: false
+
     onPluginServiceChanged: {
         if (!pluginService)
             return;
         const savedId = pluginService.loadPluginData("dankKDEConnect", "selectedDeviceId", "");
         if (savedId)
             selectedDeviceId = savedId;
+        settingsLoaded = true;
     }
 
     Timer {
@@ -574,11 +583,32 @@ PluginComponent {
     Connections {
         target: PhoneConnectService
         function onDevicesListChanged() {
+            if (!root.settingsLoaded)
+                return;
             const ids = PhoneConnectService.deviceIds;
-            if (ids.length === 0) {
-                selectDevice("");
-            } else if (!selectedDeviceId || !ids.includes(selectedDeviceId)) {
+            // A momentarily empty list (e.g. a brief D-Bus/kdeconnectd hiccup
+            // right after startup) does NOT mean the saved device preference
+            // should be forgotten - `hasDevice` already goes false on its own
+            // when selectedDeviceId isn't in `ids`, so the UI reacts correctly
+            // without us clearing (and persisting the loss of) the selection.
+            if (ids.length > 0 && !selectedDeviceId) {
+                // Only auto-pick a device when nothing has ever been selected.
+                // Do NOT reassign just because the saved device hasn't shown up
+                // in this particular discovery pass yet (e.g. a phone connects
+                // slower than an always-on LAN device) - it will become active
+                // again on its own once it appears in `ids`.
                 selectDevice(ids[0]);
+            }
+        }
+
+        function onDeviceRemoved(deviceId) {
+            // deviceRemoved is only emitted for genuine registry removals
+            // (unpair/forget), unlike plain absence from a devicesListChanged
+            // snapshot - so it's safe to actually clear the saved selection
+            // here. devicesListChanged fires right after this and will pick
+            // a replacement automatically if one remains.
+            if (deviceId === root.selectedDeviceId) {
+                selectDevice("");
             }
         }
 


### PR DESCRIPTION
## Problem

`DankKDEConnect.qml` reassigned the selected device whenever it wasn't
present in the current `deviceIds` snapshot — including a transient empty
snapshot that occurs right after shell startup while kdeconnectd is still
coming up over D-Bus. With two devices on the network, the saved phone kept
getting silently overwritten by whichever other device responded first, on
almost every restart.

Confirmed by polling `plugin_settings.json`'s `selectedDeviceId` across
restarts: it held for ~7s, briefly cleared, then flipped to the wrong
device within the next second — and stayed wrong until manually reselected.

## Fix

- Only auto-pick a device when nothing was ever selected (first run). A
  momentarily empty/incomplete snapshot no longer clears or reassigns the
  saved choice — `hasDevice` already goes false on its own while the real
  device is briefly absent, and the existing switcher UI already surfaces
  in that state.
- Genuine removal (unpair + gone from the network) is now detected via the
  `deviceRemoved` signal instead of inferring it from snapshot absence, so
  real removals still auto-recover to another device, just without
  reacting to timing noise.
- Added a small `settingsLoaded` guard so a device-list event arriving
  before the saved preference has loaded can't be mistaken for "nothing
  was ever selected".

## Testing

- Restarted the shell repeatedly while polling the persisted selection
  every second: before the fix, it flipped to the wrong device within
  ~10s of every restart; after, it stayed correct across every run.
- Tested "forget device" on a real paired phone: unpairing while it stayed
  on the LAN only emits `pairStateChanged`/`deviceListChanged`, not
  `deviceRemoved` — selection stayed correct throughout. Separately
  confirmed `deviceRemoved` does fire once a device is both unpaired and
  unreachable (observed with another device going fully offline), which
  is exactly what the new handler targets. Re-paired the phone afterward.