### PR TITLE
Fix "Permission denied" error when invoking dankHooks

### DIFF
--- a/DankHooks/DankHooks.qml
+++ b/DankHooks/DankHooks.qml
@@ -281,12 +281,7 @@ PluginComponent {
             property string hookName: ""
             property string hookValue: ""
 
-            command: ["sh", "-c", "$HOOK_SCRIPT \"$HOOK_NAME\" \"$HOOK_VALUE\""]
-            environment: {
-                "HOOK_SCRIPT": hookScript,
-                "HOOK_NAME": hookName,
-                "HOOK_VALUE": hookValue
-            }
+            command: ["sh", "-c", "export HOOK_SCRIPT=\"$1\" HOOK_NAME=\"$2\" HOOK_VALUE=\"$3\"; exec \"$1\" \"$2\" \"$3\"", "dankhooks", hookScript, hookName, hookValue]
 
             stdout: StdioCollector {
                 onStreamFinished: {


### PR DESCRIPTION
### Problem

When any hook is invoked, I get a pink-colored toast that says "Hook Script Error" with the following message:

```
/usr/bin/sh: 1: : Permission denied
```

The script has appropriate permission though, in fact, dankHooks fails before invoking the script.

### Cause

`Process.environment` is declared as a `QVariantHash`. The QML engine converts a JavaScript object literal to `QVariantMap`, but has no conversion to `QVariantHash`, so the assignment fails, and the following warning messages appear in the QML log:

```
Could not convert [object Object] to QVariantHash
```

None of the environment variables `HOOK_SCRIPT`, `HOOK_NAME`, or `HOOK_VALUE` are assigned, and `sh -c '$HOOK_SCRIPT "$HOOK_NAME" "$HOOK_VALUE"'` expands to `sh -c '""'`. Sure enough:

```
$ sh -c '""'
sh: 1: : Permission denied
```

### Fix

Use positional argument and assign the environment variables as trailing arguments, like so:

```
command: ["sh", "-c", "export HOOK_SCRIPT=\"$1\" HOOK_NAME=\"$2\" HOOK_VALUE=\"$3\"; exec \"$1\" \"$2\" \"$3\"", "dankhooks", hookScript, hookName, hookValue]
```

### Testing

Restarted the dms with the patched dankHooks and verified that the hooks get invoked. No error toast appears, and no warnings are present in the qml log.